### PR TITLE
don't break lines on the created at string

### DIFF
--- a/assets/row.html
+++ b/assets/row.html
@@ -1,7 +1,7 @@
 <div
   class="flex flex-col sm:flex-row px-2 space-x-0 sm:space-x-5 border-b border-gray-100 py-1 font-mono font-extralight"
 >
-  <div class="flex items-center text-gray-400">
+  <div class="flex items-center text-gray-400 whitespace-nowrap">
     {{ formatTime .CreatedAt }}
   </div>
 


### PR DESCRIPTION
When large log lines wrap, the layout tries to restructure the row by wrapping any available whitespace in the other cells. Set nowrap on the created at string so the column stays consistent.

Without the change:
<img width="931" alt="Screenshot 2023-03-04 at 9 07 19 AM" src="https://user-images.githubusercontent.com/49688/222919371-02520cfe-c942-4ae9-8255-27d1051709e4.png">

With change:
<img width="933" alt="Screenshot 2023-03-04 at 9 06 39 AM" src="https://user-images.githubusercontent.com/49688/222919375-b115b478-e72e-43e2-9a1f-57a181c299be.png">
